### PR TITLE
Python3.6 error of virtual_dav_provider.py example

### DIFF
--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -1522,7 +1522,8 @@ class RequestServer(object):
                 readbuffer = fileobj.read(self.block_size)
             else:
                 readbuffer = fileobj.read(contentlengthremaining)
-            assert compat.is_bytes(readbuffer)
+            if not compat.is_bytes(readbuffer):
+                readbuffer = compat.to_bytes(readbuffer)
             yield readbuffer
             contentlengthremaining -= len(readbuffer)
             if len(readbuffer) == 0 or contentlengthremaining == 0:


### PR DESCRIPTION
I tried to get the virtual_dav_provider.py example working with WsgiDAV/2.3.0 Cheroot/6.2.4 Python/3.6.3 .

However, I got an error when accessing the virtual meta data files:

    <123145538461696> [20:55:40.741] wsgidav:  ErrorPrinter: caught Exception
    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/error_printer.py", line 55, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_resolver.py", line 206, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 129, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 1526, in _sendResource
        assert compat.is_bytes(readbuffer)
    AssertionError
    ValueError("invalid literal for int() with base 10: ''",)
    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/wsgi.py", line 140, in respond
        for chunk in filter(None, response):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/wsgidav_app.py", line 435, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/debug_filter.py", line 161, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/error_printer.py", line 55, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_resolver.py", line 206, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 129, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 1526, in _sendResource
        assert compat.is_bytes(readbuffer)
    AssertionError

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1193, in communicate
        req.respond()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 997, in respond
        self.server.gateway(self).respond()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/wsgi.py", line 146, in respond
        self.req.ensure_headers_sent()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1044, in ensure_headers_sent
        self.send_headers()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1061, in send_headers
        status = int(self.status[:3])
    ValueError: invalid literal for int() with base 10: ''
    <123145543716864> [20:55:40.747] wsgidav:  ErrorPrinter: caught Exception
    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/error_printer.py", line 55, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_resolver.py", line 206, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 129, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 1526, in _sendResource
        assert compat.is_bytes(readbuffer)
    AssertionError
    ValueError("invalid literal for int() with base 10: ''",)
    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/wsgi.py", line 140, in respond
        for chunk in filter(None, response):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/wsgidav_app.py", line 435, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/debug_filter.py", line 161, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/error_printer.py", line 55, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_resolver.py", line 206, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 129, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 1526, in _sendResource
        assert compat.is_bytes(readbuffer)
    AssertionError

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1193, in communicate
        req.respond()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 997, in respond
        self.server.gateway(self).respond()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/wsgi.py", line 146, in respond
        self.req.ensure_headers_sent()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1044, in ensure_headers_sent
        self.send_headers()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1061, in send_headers
        status = int(self.status[:3])
    ValueError: invalid literal for int() with base 10: ''
    <123145548972032> [20:55:40.751] wsgidav:  ErrorPrinter: caught Exception
    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/error_printer.py", line 55, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_resolver.py", line 206, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 129, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 1526, in _sendResource
        assert compat.is_bytes(readbuffer)
    AssertionError
    ValueError("invalid literal for int() with base 10: ''",)
    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/wsgi.py", line 140, in respond
        for chunk in filter(None, response):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/wsgidav_app.py", line 435, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/debug_filter.py", line 161, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/error_printer.py", line 55, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_resolver.py", line 206, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 129, in __call__
        for v in app_iter:
      File "/anaconda/envs/python3/lib/python3.6/site-packages/wsgidav/request_server.py", line 1526, in _sendResource
        assert compat.is_bytes(readbuffer)
    AssertionError

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1193, in communicate
        req.respond()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 997, in respond
        self.server.gateway(self).respond()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/wsgi.py", line 146, in respond
        self.req.ensure_headers_sent()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1044, in ensure_headers_sent
        self.send_headers()
      File "/anaconda/envs/python3/lib/python3.6/site-packages/cheroot/server.py", line 1061, in send_headers
        status = int(self.status[:3])
    ValueError: invalid literal for int() with base 10: ''

There is probably a more elegant way, but the attached commit fixes it. 

Thanks for maintaining this library, it's great!
